### PR TITLE
RDKE-728: Move NetworkManager Dispatcher scripts to Middleware

### DIFF
--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -7,6 +7,7 @@ ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "prodlog-
 ROOTFS_POSTPROCESS_COMMAND += " common_image_hook; "
 ROOTFS_POSTPROCESS_COMMAND += " create_NM_link; "
 ROOTFS_POSTPROCESS_COMMAND += " remove_hvec_asset; "
+ROOTFS_POSTPROCESS_COMMAND += " modify_NM; "
 
 R = "${IMAGE_ROOTFS}"
 
@@ -114,4 +115,11 @@ remove_hvec_asset(){
     if [ -f "${R}/var/sky/assets/Vision50V95_HEVC.mp4" ]; then
         rm -rf ${R}/var/sky/assets/Vision50V95_HEVC.mp4
     fi
+}
+
+# Required for NetworkManager
+modify_NM() {
+        rm ${IMAGE_ROOTFS}/etc/NetworkManager/dispatcher.d/nlmon-script.sh
+        sed -i "s/dns=dnsmasq//g" ${IMAGE_ROOTFS}/etc/NetworkManager/NetworkManager.conf
+        sed -i '16i ExecStartPost=/bin/sh /lib/rdk/NM_restartConn.sh' ${IMAGE_ROOTFS}/lib/systemd/system/NetworkManager.service
 }

--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -105,10 +105,8 @@ disable_agetty() {
 
 # Required for NetworkManager
 create_NM_link() {
-        if ${@bb.utils.contains("DISTRO_FEATURES", "ENABLE_NETWORKMANAGER", "true", "false", d)}; then
-            ln -sf /var/run/NetworkManager/no-stub-resolv.conf ${R}/etc/resolv.dnsmasq
-            ln -sf /var/run/NetworkManager/resolv.conf ${R}/etc/resolv.conf
-        fi
+    ln -sf /var/run/NetworkManager/no-stub-resolv.conf ${R}/etc/resolv.dnsmasq
+    ln -sf /var/run/NetworkManager/resolv.conf ${R}/etc/resolv.conf
 }
 
 remove_hvec_asset(){


### PR DESCRIPTION
Reason for change: Move NetworkManager Dispatcher scripts to Middleware
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)