### PR TITLE
RDKOSS-105: Exclude AUTOINC tag

### DIFF
--- a/classes/tag_to_sha_converter.bbclass
+++ b/classes/tag_to_sha_converter.bbclass
@@ -73,7 +73,7 @@ python convert_tag_to_sha() {
                 bb.fatal("ERROR: The URL '%s' for %s uses an invalid git protocol: '%s'" % (url, pn, protocol))
             srcrev_var, srcrev =  get_srcrev(d, name) or (None, None)
             # Check if the srcrev is a tag
-            if srcrev:
+            if srcrev and srcrev != "AUTOINC":
                 # Anything that doesn't look like a sha256 checksum/revision is considered as tag
                 if len(srcrev) != 40 or (False in [c in "abcdef0123456789" for c in srcrev.lower()]):
                    if user:


### PR DESCRIPTION
Reason for the change:
The AUTOINC is being treated as a tag for the recipes that are using AUTOREV in SRCREV and causing build failures. This case can be excluded.