### PR TITLE
RDKE-753 Refactor post rootfs tasks and rdk specific configs to sysint

### DIFF
--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -117,12 +117,8 @@ remove_hvec_asset(){
 
 # Required for NetworkManager
 modify_NM() {
-    if [ -f "${R}/etc/NetworkManager/dispatcher.d/nlmon-script.sh" ]; then
-        bbnote "inside the loop"
-        rm -f ${R}/etc/NetworkManager/dispatcher.d/nlmon-script.sh
-    fi
+    
     if [ -f "${R}/etc/NetworkManager/NetworkManager.conf" ]; then
-        bbnote "outside the loop"
         sed -i "s/dns=dnsmasq//g" ${R}/etc/NetworkManager/NetworkManager.conf
     fi
 }

--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -118,6 +118,7 @@ remove_hvec_asset(){
 # Required for NetworkManager
 modify_NM() {
     if [ -f "${R}/etc/NetworkManager/dispatcher.d/nlmon-script.sh" ]; then
+        bbnote "[RDM] inside the loop"
         rm -f ${R}/etc/NetworkManager/dispatcher.d/nlmon-script.sh
     fi
     if [ -f "${R}/etc/NetworkManager/NetworkManager.conf" ]; then

--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -118,10 +118,11 @@ remove_hvec_asset(){
 # Required for NetworkManager
 modify_NM() {
     if [ -f "${R}/etc/NetworkManager/dispatcher.d/nlmon-script.sh" ]; then
-        bbnote "[RDM] inside the loop"
+        bbnote "inside the loop"
         rm -f ${R}/etc/NetworkManager/dispatcher.d/nlmon-script.sh
     fi
     if [ -f "${R}/etc/NetworkManager/NetworkManager.conf" ]; then
+        bbnote "outside the loop"
         sed -i "s/dns=dnsmasq//g" ${R}/etc/NetworkManager/NetworkManager.conf
     fi
 }


### PR DESCRIPTION
RDKE-753 Refactor post rootfs tasks and rdk specific configs to sysint
Reason for change: Moving the NetworkManager files from oss layer to sysint recipe
Test Procedure: Make sure the network related functionalities are working as expected.

Risks: Medium
Priority: P1

Signed-off-by: Vismal S Kumar [ajvismal@yahoo.com](mailto:ajvismal@yahoo.com)