### PR TITLE
RDKTV-36648: USB Drive Fails to Launch in Offline Mode After Restart via Settings

### DIFF
--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -105,9 +105,11 @@ disable_agetty() {
 
 # Required for NetworkManager
 create_NM_link() {
-    touch /var/run/NetworkManager/resolv.conf
+    touch ${R}/etc/resolv.conf
+    echo "nameserver 127.0.0.1" > ${R}/etc/resolv.conf
+    echo "options timeout:1" >> ${R}/etc/resolv.conf
+    echo "options attempts:2" >> ${R}/etc/resolv.conf
     ln -sf /var/run/NetworkManager/no-stub-resolv.conf ${R}/etc/resolv.dnsmasq
-    ln -sf /var/run/NetworkManager/resolv.conf ${R}/etc/resolv.conf
 }
 
 remove_hvec_asset(){

--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -105,6 +105,7 @@ disable_agetty() {
 
 # Required for NetworkManager
 create_NM_link() {
+    touch /var/run/NetworkManager/resolv.conf
     ln -sf /var/run/NetworkManager/no-stub-resolv.conf ${R}/etc/resolv.dnsmasq
     ln -sf /var/run/NetworkManager/resolv.conf ${R}/etc/resolv.conf
 }


### PR DESCRIPTION
Reason for change: Make sure resolv.conf is created even in offline mode
Test Procedure: Build RDKE image and check resolv.conf in offline mode
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)