### PR TITLE
RDK-58119 Update license_create_manifest_pdf.bbclass to support local file system

### DIFF
--- a/classes/license_create_manifest_pdf.bbclass
+++ b/classes/license_create_manifest_pdf.bbclass
@@ -110,7 +110,7 @@ pull_license_frm_artifactory() {
     echo "Machine: $machine"
     echo $artifactory_paths
     # From below path variable "artifactory_paths" we removed some sensitive strings about IPK server path which need to be reworked or reconstructed after open-sourcing.
-    artifactory_paths=$(echo $artifactory_paths | tr ' ' '\n' | grep -o -e 'http[s]*://[^ ]*' -e 'file*://[^ ]*')
+    artifactory_paths=$(echo $artifactory_paths | tr ' ' '\n' | grep -o -e 'http[s]*://[^ ]*' -e 'file*:[/][^ ]*')
     echo "Final artifactory paths: $artifactory_paths"
     for artifactory_path in $artifactory_paths; do
         set +e

--- a/classes/license_create_manifest_pdf.bbclass
+++ b/classes/license_create_manifest_pdf.bbclass
@@ -110,7 +110,7 @@ pull_license_frm_artifactory() {
     echo "Machine: $machine"
     echo $artifactory_paths
     # From below path variable "artifactory_paths" we removed some sensitive strings about IPK server path which need to be reworked or reconstructed after open-sourcing.
-    artifactory_paths=$(echo $artifactory_paths | tr ' ' '\n' | grep -o 'http[s]*://[^ ]*')
+    artifactory_paths=$(echo $artifactory_paths | tr ' ' '\n' | grep -o -e 'http[s]*://[^ ]*' -e 'file*://[^ ]*')
     echo "Final artifactory paths: $artifactory_paths"
     for artifactory_path in $artifactory_paths; do
         set +e


### PR DESCRIPTION
Reason for change: To allow license manifest pdf generation when IPK feeds are on the local file system instead of a remote server. So the class should allow file:// as well as https://
Test Procedure: license manifest pdf generation is OK when IPKs are local
Risks: Low