### PR TITLE
XIONE-17490: Include systemd-analyze in dbg builds

### DIFF
--- a/classes/perfomance-debug-tools-packages.bbclass
+++ b/classes/perfomance-debug-tools-packages.bbclass
@@ -1,2 +1,4 @@
 #Install performance and debug tools as required in RDK_TOOLS_PACKAGES
 IMAGE_INSTALL:append = " ${@d.getVar("RDK_TOOLS_PACKAGES", True) or ""} "
+
+IMAGE_INSTALL:append = "${@bb.utils.contains('BUILD_VARIANT', 'debug', " systemd-analyze", "", d)}" 


### PR DESCRIPTION
Reason for the change: Systemd-analyze should be included in the debug build variant, as it provides critical insights for troubleshooting service failures and dependencies.