### PR TITLE
RDK-57904: Update Dnsmasq to be managed by NetworkManager

### DIFF
--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -103,24 +103,8 @@ disable_agetty() {
     fi
 }
 
-# Required for NetworkManager
-create_NM_link() {
-    ln -sf /var/run/NetworkManager/no-stub-resolv.conf ${R}/etc/resolv.dnsmasq
-    ln -sf /var/run/NetworkManager/resolv.conf ${R}/etc/resolv.conf
-}
-
 remove_hvec_asset(){
     if [ -f "${R}/var/sky/assets/Vision50V95_HEVC.mp4" ]; then
         rm -rf ${R}/var/sky/assets/Vision50V95_HEVC.mp4
-    fi
-}
-
-# Required for NetworkManager
-modify_NM() {
-    if [ -f "${R}/etc/NetworkManager/dispatcher.d/nlmon-script.sh" ]; then
-        rm -f ${R}/etc/NetworkManager/dispatcher.d/nlmon-script.sh
-    fi
-    if [ -f "${R}/etc/NetworkManager/NetworkManager.conf" ]; then
-        sed -i "s/dns=dnsmasq//g" ${R}/etc/NetworkManager/NetworkManager.conf
     fi
 }

--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -5,9 +5,7 @@ ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "debug-va
 ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "prod-variant", "prod_image_hook; ", "", d)}'
 ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "prodlog-variant", "prodlog_image_hook; ", "", d)}'
 ROOTFS_POSTPROCESS_COMMAND += " common_image_hook; "
-ROOTFS_POSTPROCESS_COMMAND += " create_NM_link; "
 ROOTFS_POSTPROCESS_COMMAND += " remove_hvec_asset; "
-ROOTFS_POSTPROCESS_COMMAND += " modify_NM; "
 
 R = "${IMAGE_ROOTFS}"
 


### PR DESCRIPTION
Reason for change: Update dnsmasq to be managed by NetworkManager.
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)