### PR TITLE
CMFSUPPORT-3454 : Add auto_pr_creation github workflow for broadband community manifests

### DIFF
--- a/.github/workflows/auto_pr_creation_target_repo_caller_broadband_community.yml
+++ b/.github/workflows/auto_pr_creation_target_repo_caller_broadband_community.yml
@@ -1,0 +1,19 @@
+name: Auto PR Creation Caller
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+      - support/dunfell
+      - 'support/*.*.*'
+
+jobs:
+  call_auto_pr_workflow:
+    uses: rdkcentral/build_tools_workflows/.github/workflows/auto_pr_creation_rdkb_manifest.yml@develop
+    secrets:
+      RDKCM_RDKE: ${{ secrets.RDKCM_RDKE }}

--- a/.github/workflows/auto_pr_creation_target_repo_caller_broadband_community.yml
+++ b/.github/workflows/auto_pr_creation_target_repo_caller_broadband_community.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   call_auto_pr_workflow:
+    if: github.event.pull_request.merged == true
     uses: rdkcentral/build_tools_workflows/.github/workflows/auto_pr_creation_rdkb_manifest.yml@develop
     secrets:
       RDKCM_RDKE: ${{ secrets.RDKCM_RDKE }}

--- a/.github/workflows/auto_pr_creation_target_repo_caller_broadband_community.yml
+++ b/.github/workflows/auto_pr_creation_target_repo_caller_broadband_community.yml
@@ -1,4 +1,4 @@
-name: Auto PR Creation Caller
+name: Auto PR Creation Caller - Broadband Community
 
 permissions:
   contents: read


### PR DESCRIPTION
Reason for change: Add auto_pr_creation_target_repo_caller_broadband_community github workflow
Automatic update of meta-rdk-auxiliary commit id in community broadband manifests

Test Procedure: Check community broadband manifests are updated with the correct SHA1 value
Risks: Low
Priority: P1