### PR TITLE
RDKEMW-9437 : Secure Unlock of Debug services(overrides) in LabSigned Build type

### DIFF
--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -44,7 +44,7 @@ update_build_type_property() {
 
 update_build_type_property_lab () {
      if [ -f "${R}/etc/device.properties" ]; then
-       sed -i 's/BUILD_TYPE=dev/BUILD_TYPE=labsigned/g' ${R}/etc/device.properties
+       sed -i 's/^BUILD_TYPE=.*/BUILD_TYPE=labsigned/g' ${R}/etc/device.properties
     fi
 }
 

--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -3,7 +3,7 @@
 
 ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "prod-variant", "prod_image_hook; ", "", d)}'
 ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "prodlog-variant", "prodlog_image_hook; ", "", d)}'
-ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "LabSigned-variant", "LabSigned_image_hook; ", "", d)}'
+ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "labSigned-variant", "labSigned_image_hook; ", "", d)}'
 ROOTFS_POSTPROCESS_COMMAND += " common_image_hook; "
 ROOTFS_POSTPROCESS_COMMAND += " create_NM_link; "
 ROOTFS_POSTPROCESS_COMMAND += " remove_hvec_asset; "
@@ -17,7 +17,7 @@ python common_prod_image_hook(){
      bb.build.exec_func('update_build_type_property', d)    
 }
 
-python LabSigned_image_hook(){
+python labSigned_image_hook(){
      bb.build.exec_func('common_prod_image_hook', d)
      bb.build.exec_func('enable_debugService_property', d)
 }

--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -18,10 +18,8 @@ python common_prod_image_hook(){
 }
 
 python labSigned_image_hook(){
-     bb.build.exec_func('cleanup_stunnel_socat', d)
-     bb.build.exec_func('update_noshadow', d)
-     bb.build.exec_func('disable_agetty', d)
-     bb.build.exec_func('update_build_type_property_lab', d)
+     bb.build.exec_func('common_prod_image_hook', d)
+     bb.build.exec_func('update_labsigned_property', d)
 }
 python prod_image_hook(){
      bb.build.exec_func('common_prod_image_hook', d)
@@ -42,10 +40,10 @@ update_build_type_property() {
     fi
 }
 
-update_build_type_property_lab () {
+update_labsigned_property() {
      if [ -f "${R}/etc/device.properties" ]; then
-       sed -i 's/^BUILD_TYPE=.*/BUILD_TYPE=labsigned/g' ${R}/etc/device.properties
-    fi
+        sed -i 's/^LABSIGNED_ENABLED=false/LABSIGNED_ENABLED=true/g' ${R}/etc/device.properties
+     fi
 }
 
 cleanup_stunnel_socat () {

--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -3,7 +3,7 @@
 
 ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "prod-variant", "prod_image_hook; ", "", d)}'
 ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "prodlog-variant", "prodlog_image_hook; ", "", d)}'
-ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "labSigned-variant", "labSigned_image_hook; ", "", d)}'
+ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "SignedLab-variant", "SignedLab_image_hook; ", "", d)}'
 ROOTFS_POSTPROCESS_COMMAND += " common_image_hook; "
 ROOTFS_POSTPROCESS_COMMAND += " create_NM_link; "
 ROOTFS_POSTPROCESS_COMMAND += " remove_hvec_asset; "
@@ -17,7 +17,7 @@ python common_prod_image_hook(){
      bb.build.exec_func('update_build_type_property', d)    
 }
 
-python labSigned_image_hook(){
+python SignedLab_image_hook(){
      bb.build.exec_func('common_prod_image_hook', d)
      bb.build.exec_func('enable_debugService_property', d)
 }
@@ -42,7 +42,7 @@ update_build_type_property() {
 
 enable_debugService_property() {
      if [ -f "${R}/etc/device.properties" ]; then
-        sed -i 's/^LABSIGNED_ENABLED=false/LABSIGNED_ENABLED=true/g' ${R}/etc/device.properties
+        sed -i 's/^SignedLab_ENABLED=false/SignedLab_ENABLED=true/g' ${R}/etc/device.properties
      fi
 }
 

--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -3,7 +3,7 @@
 
 ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "prod-variant", "prod_image_hook; ", "", d)}'
 ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "prodlog-variant", "prodlog_image_hook; ", "", d)}'
-ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "labSigned-variant", "labSigned_image_hook; ", "", d)}'
+ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "DbgBuild_ProdHw-variant", "DbgBuild_ProdHw_image_hook; ", "", d)}'
 ROOTFS_POSTPROCESS_COMMAND += " common_image_hook; "
 ROOTFS_POSTPROCESS_COMMAND += " create_NM_link; "
 ROOTFS_POSTPROCESS_COMMAND += " remove_hvec_asset; "
@@ -17,9 +17,9 @@ python common_prod_image_hook(){
      bb.build.exec_func('update_build_type_property', d)    
 }
 
-python labSigned_image_hook(){
+python DbgBuild_ProdHw_image_hook(){
      bb.build.exec_func('common_prod_image_hook', d)
-     bb.build.exec_func('update_labsigned_property', d)
+     bb.build.exec_func('enable_debugService_property', d)
 }
 python prod_image_hook(){
      bb.build.exec_func('common_prod_image_hook', d)
@@ -40,9 +40,9 @@ update_build_type_property() {
     fi
 }
 
-update_labsigned_property() {
+enable_debugService_property() {
      if [ -f "${R}/etc/device.properties" ]; then
-        sed -i 's/^LABSIGNED_ENABLED=false/LABSIGNED_ENABLED=true/g' ${R}/etc/device.properties
+        sed -i 's/^DBGSERVICES_ENABLED=false/DBGSERVICES_ENABLED=true/g' ${R}/etc/device.properties
      fi
 }
 

--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -3,7 +3,7 @@
 
 ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "prod-variant", "prod_image_hook; ", "", d)}'
 ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "prodlog-variant", "prodlog_image_hook; ", "", d)}'
-ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "DbgBuild_ProdHw-variant", "DbgBuild_ProdHw_image_hook; ", "", d)}'
+ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "LabSigned-variant", "LabSigned_image_hook; ", "", d)}'
 ROOTFS_POSTPROCESS_COMMAND += " common_image_hook; "
 ROOTFS_POSTPROCESS_COMMAND += " create_NM_link; "
 ROOTFS_POSTPROCESS_COMMAND += " remove_hvec_asset; "
@@ -17,7 +17,7 @@ python common_prod_image_hook(){
      bb.build.exec_func('update_build_type_property', d)    
 }
 
-python DbgBuild_ProdHw_image_hook(){
+python LabSigned_image_hook(){
      bb.build.exec_func('common_prod_image_hook', d)
      bb.build.exec_func('enable_debugService_property', d)
 }
@@ -42,7 +42,7 @@ update_build_type_property() {
 
 enable_debugService_property() {
      if [ -f "${R}/etc/device.properties" ]; then
-        sed -i 's/^DBGBUILD_PRODHW=false/DBGBUILD_PRODHW=true/g' ${R}/etc/device.properties
+        sed -i 's/^LABSIGNED_ENABLED=false/LABSIGNED_ENABLED=true/g' ${R}/etc/device.properties
      fi
 }
 

--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -42,7 +42,7 @@ update_build_type_property() {
 
 enable_debugService_property() {
      if [ -f "${R}/etc/device.properties" ]; then
-        sed -i 's/^SignedLab_ENABLED=false/SignedLab_ENABLED=true/g' ${R}/etc/device.properties
+        sed -i 's/^LABSIGNED_ENABLED=false/LABSIGNED_ENABLED=true/g' ${R}/etc/device.properties
      fi
 }
 

--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -21,7 +21,7 @@ python labSigned_image_hook(){
      bb.build.exec_func('cleanup_stunnel_socat', d)
      bb.build.exec_func('update_noshadow', d)
      bb.build.exec_func('disable_agetty', d)
-     bb.build.exec_function('update_build_type_property_lab', d)
+     bb.build.exec_func('update_build_type_property_lab', d)
 }
 python prod_image_hook(){
      bb.build.exec_func('common_prod_image_hook', d)

--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -3,6 +3,7 @@
 
 ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "prod-variant", "prod_image_hook; ", "", d)}'
 ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "prodlog-variant", "prodlog_image_hook; ", "", d)}'
+ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "labSigned-variant", "labSigned_image_hook; ", "", d)}'
 ROOTFS_POSTPROCESS_COMMAND += " common_image_hook; "
 ROOTFS_POSTPROCESS_COMMAND += " create_NM_link; "
 ROOTFS_POSTPROCESS_COMMAND += " remove_hvec_asset; "
@@ -16,6 +17,12 @@ python common_prod_image_hook(){
      bb.build.exec_func('update_build_type_property', d)    
 }
 
+python labSigned_image_hook(){
+     bb.build.exec_func('cleanup_stunnel_socat', d)
+     bb.build.exec_func('update_noshadow', d)
+     bb.build.exec_func('disable_agetty', d)
+     bb.build.exec_function('update_build_type_property_lab', d)
+}
 python prod_image_hook(){
      bb.build.exec_func('common_prod_image_hook', d)
 }
@@ -32,6 +39,12 @@ python common_image_hook(){
 update_build_type_property() {
     if [ -f "${R}/etc/device.properties" ]; then
        sed -i 's/BUILD_TYPE=dev/BUILD_TYPE=prod/g' ${R}/etc/device.properties
+    fi
+}
+
+update_build_type_property_lab () {
+     if [ -f "${R}/etc/device.properties" ]; then
+       sed -i 's/BUILD_TYPE=dev/BUILD_TYPE=labsigned/g' ${R}/etc/device.properties
     fi
 }
 

--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -42,7 +42,7 @@ update_build_type_property() {
 
 enable_debugService_property() {
      if [ -f "${R}/etc/device.properties" ]; then
-        sed -i 's/^DBGSERVICES_ENABLED=false/DBGSERVICES_ENABLED=true/g' ${R}/etc/device.properties
+        sed -i 's/^DBGBUILD_PRODHW=false/DBGBUILD_PRODHW=true/g' ${R}/etc/device.properties
      fi
 }
 


### PR DESCRIPTION
Reason for change: to enable debug services, only if the build vairant is labSigned and device is test type
Test Procedure: Flash the image and check for enabling secure debug services
Risks: Low