### PR TITLE
RDKMVE-1639: Fix the issues in install-factoryapps bbclass and update its documentation

### DIFF
--- a/classes/install-factoryapps.bbclass
+++ b/classes/install-factoryapps.bbclass
@@ -1,3 +1,22 @@
+##########################################################################
+# If not stated otherwise in this file or this component's LICENSE
+# file the following copyright and licenses apply:
+#
+# Copyright 2026 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
 # Factory Apps Installer BBClass
 #
 # Installs factory applications into rootfs during image creation.
@@ -165,41 +184,48 @@ python factory_apps_installer_run() {
 
             # Extract fields
             package_name = app.get("packagename", "")
-            src_path = app.get("srcpath", "")
+            src_uri = app.get("srcuri", "")
             sha_value = app.get("sha256sum", "")
 
             if not package_name:
                 bb.warn(f"Factory app entry #{idx} missing 'packagename': {app}")
                 return False
-            if not src_path:
-                bb.warn(f"Factory app entry #{idx} ('{package_name}') missing source path field: {app}")
+            if not src_uri:
+                bb.warn(f"Factory app entry #{idx} ('{package_name}') missing required field 'srcuri': {app}")
                 return False
 
-            # Validate package name - prevent directory traversal
-            if ".." in package_name or package_name.startswith("/") or package_name.startswith("\\"):
-                bb.fatal(f"Invalid packagename '{package_name}': potential directory traversal detected")
+            # Validate package name - prevent directory traversal and enforce plain filename
+            if ".." in package_name or "/" in package_name or "\\" in package_name:
+                bb.fatal(
+                    f"Invalid packagename '{package_name}': must be a plain filename (no '..', '/' or '\\\\') "
+                    "to prevent directory traversal and ensure the artifact is installed directly under "
+                    "FACTORY_APPS_PATH"
+                )
 
-            # Enforce plain filename to avoid nested paths and traversal complexity
-            if "/" in package_name or "\\" in package_name:
-                bb.fatal(f"Invalid packagename '{package_name}': must be a plain filename (no '/' or '\\')")
-
-            bb.note(f"Processing factory app [{idx}]: packagename='{package_name}', srcpath='{src_path}'")
+            bb.note(f"Processing factory app [{idx}]: packagename='{package_name}', srcuri='{src_uri}'")
 
             # Use BitBake fetcher to handle all protocols (file://, http://, https://, ftp://, etc.)
-            local_file = fetch_file(src_path, sha_value, package_name)
+            local_file = fetch_file(src_uri, sha_value, package_name)
 
             # Copy the fetched file
             copy_package(local_file, package_name)
             return True
 
         except Exception as e:
-            # Include index and, when available, packagename and srcpath for easier troubleshooting
+            # Preserve BitBake fatal errors (bb.fatal) as build-stoppers.
+            # bb.fatal raises bb.BBHandledException; do not downgrade it to a warning.
+            if hasattr(bb, "BBHandledException") and isinstance(e, bb.BBHandledException):
+                raise
+
+            # Include index and, when available, packagename and srcuri for easier troubleshooting
             pkg_name = app.get("packagename") if isinstance(app, dict) else None
-            src_path = app.get("srcpath") if isinstance(app, dict) else None
+            src_uri = None
+            if isinstance(app, dict):
+                src_uri = app.get("srcuri")
             bb.warn(
                 f"Failed to process package at index {idx}"
                 f"{f', packagename={pkg_name!r}' if pkg_name else ''}"
-                f"{f', srcpath={src_path!r}' if src_path else ''}: {e}"
+                f"{f', srcuri={src_uri!r}' if src_uri else ''}: {e}"
             )
             return False
 

--- a/docs/install-factoryapps.md
+++ b/docs/install-factoryapps.md
@@ -9,7 +9,9 @@ Apps are described by a JSON manifest. Each entry provides a fetch URI, which is
 - Runs as a rootfs postprocess hook (`ROOTFS_POSTPROCESS_COMMAND`).
 - Fetches via `bb.fetch2` (cached in `DL_DIR`) and installs into `${IMAGE_ROOTFS}${FACTORY_APPS_PATH}/<packagename>` with mode `0644`.
 - Validates `packagename` to prevent obvious directory traversal.
-- Skips invalid entries (wrong type, missing or empty fields) with a warning.
+- The class warns and skips an entry when it is malformed (wrong entry type, missing/empty fields).
+- The class fails the build (`bb.fatal`) for security- or correctness-critical errors such as invalid `packagename`, fetch failures, or fetched-file validation failures (because the requested artifact cannot be reliably installed).
+- Configuration/manifest problems are fatal and fail the build. This includes `FACTORY_APPS_PATH` not set when installation is enabled, an unreadable/unparseable manifest, a manifest that is not a JSON list, or an invalid `FACTORY_APPS_PATH`.
 - Duplicate `packagename` entries overwrite earlier installs and missing `sha256sum` warns and proceeds without verification.
 
 ## Configuration
@@ -29,10 +31,10 @@ The manifest must be a JSON array (list) of objects.
 Each entry supports:
 - `packagename` (required)
   - Destination filename within `${FACTORY_APPS_PATH}`.
-  - Must not contain `..` and must not start with `/` or `\`.
+  - Must be a plain filename (no `/` or `\\` allowed anywhere) and must not contain `..`.
 
-- `srcpath` (required)
-  - Fetch URI for the app artifact.
+- `srcuri` (required)
+  - Fetch URI for the app artifact (must resolve to a single file, not a directory).
   - Examples: `https://example.com/app.bolt`, `file:///path/to/app.bolt`.
 
 - `sha256sum` (required)
@@ -45,7 +47,7 @@ Each entry supports:
 [
   {
     "packagename": "app.bolt",
-    "srcpath": "https://example.com/app.bolt",
+    "srcuri": "https://example.com/app.bolt",
     "sha256sum": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
   }
 ]


### PR DESCRIPTION
Reason for Change:
 - Change to `srcuri` in factory apps JSON manifest instead of `srcpath` to convey the functional requirement
 - Improve packagename validation messaging (plain filename to prevent traversal)
 - Ensure bb.fatal errors (fetch/validation) fail the build as intended
 - Update documentation to reflect fatal vs warn/skip behavior and new srcuri field