### PR TITLE
RDKOSS-706: Set right permission to OSS repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @rdkcentral/rdke_ghec_meta_oss_admin
+*       @rdkcentral/rdke_ghec_meta_oss_maintainer @rdkcentral/rdke_ghec_meta_oss_admin


### PR DESCRIPTION
Add rdkcentral/rdke_ghec_meta_oss_maintainer to  CODEOWNERS