### PR TITLE
RDKMVE-1639, RDKMVE-1591: install-factoryapps bbclass - align variable name with common config and middleware

### DIFF
--- a/classes/install-factoryapps.bbclass
+++ b/classes/install-factoryapps.bbclass
@@ -23,13 +23,13 @@
 #
 # Configuration:
 #   FACTORY_APPS_JSON_FILE - Path to JSON manifest
-#   FACTORY_APPS_PATH      - Default installation directory for all apps (optional)
+#   FACTORY_APP_PATH      - Default installation directory for all apps (optional)
 #                           If unset, each app in the manifest must define its own
 #                           "installpath" field.
 #
 # JSON manifest:
 #   Each app entry may optionally specify "installpath" to override the default
-#   FACTORY_APPS_PATH for that specific app.
+#   FACTORY_APP_PATH for that specific app.
 #
 # Detailed documentation:
 # See: docs/install-factoryapps.md
@@ -50,7 +50,7 @@ python factory_apps_installer_run() {
 
     json_file = d.getVar("FACTORY_APPS_JSON_FILE")
     rootfs = d.getVar("IMAGE_ROOTFS")
-    default_install_path = d.getVar("FACTORY_APPS_PATH")
+    default_install_path = d.getVar("FACTORY_APP_PATH")
 
     if not json_file:
         bb.warn("FACTORY_APPS_JSON_FILE not set; skipping factory apps install")
@@ -61,7 +61,7 @@ python factory_apps_installer_run() {
         return
 
     if not isinstance(default_install_path, str) or not default_install_path.strip():
-        bb.warn("FACTORY_APPS_PATH not set; each app must specify its own 'installpath' in the JSON manifest")
+        bb.warn("FACTORY_APP_PATH not set; each app must specify its own 'installpath' in the JSON manifest")
 
     def normalize_and_validate_install_path(path_value):
         """Validate path and return a normalized POSIX path.
@@ -73,22 +73,22 @@ python factory_apps_installer_run() {
 
         raw = path_value.strip()
 
-        # Treat FACTORY_APPS_PATH as a target (POSIX) path; reject Windows separators.
+        # Treat FACTORY_APP_PATH as a target (POSIX) path; reject Windows separators.
         if "\\" in raw:
-            bb.fatal(f"Invalid FACTORY_APPS_PATH '{raw}': backslashes are not allowed")
+            bb.fatal(f"Invalid FACTORY_APP_PATH '{raw}': backslashes are not allowed")
 
         if not raw.startswith("/"):
-            bb.fatal(f"Invalid FACTORY_APPS_PATH '{raw}': must be an absolute path (start with '/')")
+            bb.fatal(f"Invalid FACTORY_APP_PATH '{raw}': must be an absolute path (start with '/')")
 
         # Reject any '..' path elements to avoid escapes when combined with IMAGE_ROOTFS.
         parts = [p for p in raw.split("/") if p]
         if any(p == ".." for p in parts):
-            bb.fatal(f"Invalid FACTORY_APPS_PATH '{raw}': '..' is not allowed")
+            bb.fatal(f"Invalid FACTORY_APP_PATH '{raw}': '..' is not allowed")
 
         normalized = posixpath.normpath(raw)
         # normpath can remove trailing slashes; ensure it remains absolute
         if not normalized.startswith("/"):
-            bb.fatal(f"Invalid FACTORY_APPS_PATH '{raw}': normalization produced a non-absolute path")
+            bb.fatal(f"Invalid FACTORY_APP_PATH '{raw}': normalization produced a non-absolute path")
 
         return normalized
 
@@ -194,7 +194,7 @@ python factory_apps_installer_run() {
         rel_dir_posix = install_path_norm.lstrip("/")
         rel_parts = [p for p in rel_dir_posix.split("/") if p]
 
-        # Build destination path: ${IMAGE_ROOTFS}${FACTORY_APPS_PATH}
+        # Build destination path: ${IMAGE_ROOTFS}${FACTORY_APP_PATH}
         dest_dir = os.path.join(rootfs, *rel_parts) if rel_parts else rootfs
         dest_file = os.path.join(dest_dir, package_name)
 
@@ -282,7 +282,7 @@ python factory_apps_installer_run() {
                 bb.fatal(
                     f"Invalid packagename '{package_name}': must be a plain filename (no '..', '/' or '\\') "
                     "to prevent directory traversal and ensure the artifact is installed directly under "
-                    "FACTORY_APPS_PATH"
+                    "FACTORY_APP_PATH"
                 )
 
             src_uri_raw = app.get("srcuri")
@@ -336,7 +336,7 @@ python factory_apps_installer_run() {
                 if not isinstance(default_install_path, str) or not default_install_path.strip():
                     bb.fatal(
                         f"Factory app entry #{idx} ('{package_name}') is missing 'installpath' and "
-                        f"default FACTORY_APPS_PATH is missing or empty."
+                        f"default FACTORY_APP_PATH is missing or empty."
                     )
                 install_path_to_use = default_install_path.strip()
 

--- a/docs/install-factoryapps.md
+++ b/docs/install-factoryapps.md
@@ -20,7 +20,7 @@ Apps are described by a JSON manifest. For each entry, the class fetches a remot
   - An invalid, missing, or empty `sha256sum`.
   - Failure to fetch an artifact.
   - Checksum validation failure for a fetched artifact.
-  - An invalid `installpath` or `FACTORY_APPS_PATH`.
+  - An invalid `installpath` or `FACTORY_APP_PATH`.
   - An attempt to write outside of `${IMAGE_ROOTFS}` or overwrite a symlink.
 - **Duplicate `packagename` entries**: The class detects and warns about duplicate `packagename` entries in the manifest. The build proceeds, and later entries in the list will overwrite artifacts installed by earlier entries with the same `packagename`.
 
@@ -31,9 +31,9 @@ Set the following variables in your image, distro config, or `local.conf`:
   - **Required**: Path on the build host to the JSON manifest file.
   - If this variable is unset or the file does not exist, the installation process is skipped with a warning.
 
-- `FACTORY_APPS_PATH`
+- `FACTORY_APP_PATH`
   - **Optional**: The default absolute installation directory inside the target `rootfs` (e.g., `/opt/factoryapps`).
-  - If this is not set, **every entry** in the JSON manifest must specify its own `installpath`. If an entry is missing `installpath` and `FACTORY_APPS_PATH` is also unset, the build will fail.
+  - If this is not set, **every entry** in the JSON manifest must specify its own `installpath`. If an entry is missing `installpath` and `FACTORY_APP_PATH` is also unset, the build will fail.
 
 ## JSON Manifest Format
 The manifest must be a JSON array (list) of objects.
@@ -55,7 +55,7 @@ Each entry supports:
 
 - `installpath` (string, optional)
   - An absolute path within the target `rootfs` where this specific artifact should be installed.
-  - This value, if provided, overrides the global `FACTORY_APPS_PATH` for this entry.
+  - This value, if provided, overrides the global `FACTORY_APP_PATH` for this entry.
   - **Validation**: Must be an absolute path (start with `/`) and must not contain `..` or `\`.
 
 ### Example Manifest
@@ -75,8 +75,4 @@ Each entry supports:
   }
 ]
 ```
-*In this example, `app1.bolt` will be installed to `/opt/apps/specific/app1.bolt`. `app2.bolt` will be installed to the directory specified by the global `FACTORY_APPS_PATH`.*
-
-
-
-
+*In this example, `app1.bolt` will be installed to `/opt/apps/specific/app1.bolt`. `app2.bolt` will be installed to the directory specified by the global `FACTORY_APP_PATH`.*


### PR DESCRIPTION
Reason for Change: Middleware and connom-config uses FACTORY_APP_PATH instead of FACTORY_APPS_PATH. Align to match.
Reference: https://github.com/rdkcentral/rdke-common-config/commit/98f3259f8a879e9fb8318fa28f431c3442e5daf5