### PR TITLE
RDKOSS-891:enrich rootfs.manifest file

### DIFF
--- a/classes/embed-source-metadata.bbclass
+++ b/classes/embed-source-metadata.bbclass
@@ -7,7 +7,8 @@
 # to assembler builds that consume pre-built IPKs without access to the
 # original recipe files.
 #
-# Source-URI: all non-file:// SRC_URI entries, normalised to HTTPS URLs.
+# Source-URI: all non-file:// SRC_URI entries, normalised to HTTPS URLs
+#   where possible (web-hosting services and ;protocol=https URIs).
 # Source-Rev: SRCREV value(s), including named SRCREVs where present.
 #
 # Counterpart: manifest-srcuri.bbclass (assembler layer) consumes these

--- a/classes/embed-source-metadata.bbclass
+++ b/classes/embed-source-metadata.bbclass
@@ -86,10 +86,10 @@ def _embed_all_src_uris(d):
 
         # Strip trailing .git for well-known web hosting services
         # and force https:// since git:// is not web-browsable on these hosts.
-        try:
-            host = url.split('://')[1].split('/')[0]
-        except IndexError:
-            host = ''
+        # Use urlsplit().hostname to correctly handle userinfo (e.g.
+        # ssh://git@github.com/...) without misidentifying git@github.com
+        # as the hostname when splitting on ://.
+        host = urlsplit(url).hostname or ''
         if any(host == h or host.endswith('.' + h) for h in WEB_HOSTS):
             url = re.sub(r'^[a-z+]+://', 'https://', url)
             url = re.sub(r'\.git$', '', url)
@@ -131,12 +131,12 @@ def _embed_all_srcrevs(d):
         # Named SRCREVs - emit as "name=rev" pairs
         pairs = []
         for name in names:
-            rev = d.getVar('SRCREV_%s' % name) or 'INVALID'
+            rev = d.getVar('SRCREV_%s' % name) or ''
             pairs.append('%s=%s' % (name, rev))
         return ' '.join(pairs)
     else:
         # Single unnamed SRCREV (or tarball-only recipe)
-        return d.getVar('SRCREV') or 'INVALID'
+        return d.getVar('SRCREV') or ''
 
 # ---------------------------------------------------------------------------
 # Append two custom fields to every IPK control file.

--- a/classes/embed-source-metadata.bbclass
+++ b/classes/embed-source-metadata.bbclass
@@ -1,0 +1,152 @@
+# embed-source-metadata.bbclass
+#
+# Embeds source provenance fields (Source-URI, Source-Rev) into the IPK
+# control file for every sub-package a recipe produces.  These fields
+# are preserved through the build pipeline into the feed's Packages index
+# and each .ipk's CONTROL/control member, making source metadata available
+# to assembler builds that consume pre-built IPKs without access to the
+# original recipe files.
+#
+# Source-URI: all non-file:// SRC_URI entries, normalised to HTTPS URLs.
+# Source-Rev: SRCREV value(s), including named SRCREVs where present.
+#
+# Counterpart: manifest-srcuri.bbclass (assembler layer) consumes these
+# fields from the feed Packages index to produce an enriched rootfs.manifest.
+#
+# Usage:
+#   INHERIT += "embed-source-metadata"  (in the building layer's conf)
+#
+# Author: Arjun <arjun_daasuramdass@comcast.com>
+
+# ---------------------------------------------------------------------------
+# Helper: return ALL meaningful (non-patch) source URIs, space-separated,
+# normalised to web-browsable HTTPS URLs so AI tools can form direct
+# file permalinks without further transformation.
+#
+# Normalisation rules applied per URI:
+#   1. Skip all file:// entries (patches, diffs, config files, service units
+#      etc.) -- none of these are remote source provenance.
+#   2. If ;protocol=https (or ;protocol=http) is present, replace the
+#      scheme in the URL with that protocol.  This handles the common
+#      BitBake pattern:  git://github.com/...;protocol=https
+#      which actually fetches over HTTPS.
+#   3. Strip all remaining ;param=value fetch parameters.
+#   4. Strip a trailing .git suffix for github.com / gitlab.com /
+#      bitbucket.org URLs, matching the canonical web URL form.
+#
+# Example input SRC_URI:
+#   git://github.com/rdkcentral/aamp.git;branch=main;protocol=https
+#   git://github.com/foo/sub.git;branch=main;name=sub
+#   file://0001-fix.patch
+#   file://my-service.conf
+#
+# Example output:
+#   https://github.com/rdkcentral/aamp https://github.com/foo/sub
+#
+# All file:// entries (patches, configs, service units, etc.) are skipped.
+# ---------------------------------------------------------------------------
+def _embed_all_src_uris(d):
+    import re
+    from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+    WEB_HOSTS = ('github.com', 'gitlab.com', 'bitbucket.org')
+    SECRET_QUERY_KEYS = {
+        'access_token', 'api_key', 'apikey', 'auth', 'awsaccesskeyid',
+        'key', 'password', 'passwd', 'signature', 'sig', 'token',
+        'x-amz-credential', 'x-amz-security-token', 'x-amz-signature',
+    }
+    def _sanitize_url(url):
+        parsed = urlsplit(url)
+        # Remove any embedded userinfo (username[:password]@) from the URL.
+        netloc = parsed.hostname or ''
+        if parsed.port is not None:
+            netloc = '%s:%s' % (netloc, parsed.port)
+        # Remove common secret-bearing query parameters.
+        query = urlencode(
+            [(k, v) for (k, v) in parse_qsl(parsed.query, keep_blank_values=True)
+             if k.lower() not in SECRET_QUERY_KEYS],
+            doseq=True,
+        )
+        return urlunsplit((parsed.scheme, netloc, parsed.path, query, ''))
+    uris = []
+    for entry in (d.getVar('SRC_URI') or '').split():
+        # Skip all local file:// entries – config files, service units, patches
+        # etc. are not remote source provenance and must not appear in the
+        # Source-URI field that flows into the Packages index / manifest.
+        if entry.startswith('file://'):
+            continue
+        parts = entry.split(';')
+        url   = parts[0]
+        params = {p.split('=')[0]: p.split('=', 1)[1]
+                  for p in parts[1:] if '=' in p}
+
+        # Apply ;protocol= to the URL scheme when present
+        protocol = params.get('protocol', '')
+        if protocol in ('https', 'http'):
+            url = re.sub(r'^[a-z+]+://', protocol + '://', url)
+
+        # Strip trailing .git for well-known web hosting services
+        # and force https:// since git:// is not web-browsable on these hosts.
+        try:
+            host = url.split('://')[1].split('/')[0]
+        except IndexError:
+            host = ''
+        if any(host == h or host.endswith('.' + h) for h in WEB_HOSTS):
+            url = re.sub(r'^[a-z+]+://', 'https://', url)
+            url = re.sub(r'\.git$', '', url)
+
+        uris.append(_sanitize_url(url))
+    return ' '.join(uris) if uris else 'unknown'
+
+# ---------------------------------------------------------------------------
+# Helper: return all SCM revisions in a compact, parseable form.
+#
+# Three cases handled:
+#
+# 1. Single unnamed repo  (SRCREV = "abc123")
+#    Output:  abc123
+#
+# 2. Single named repo    (SRCREV_main = "abc123", SRCREV_FORMAT = "main")
+#    Output:  main=abc123
+#
+# 3. Multiple named repos (SRCREV_main = "abc123", SRCREV_sub = "def456",
+#                          SRCREV_FORMAT = "main_sub")
+#    Output:  main=abc123 sub=def456
+#
+# The name= pairs format is directly readable by humans and parsers alike.
+# The manifest-srcuri.bbclass on the assembler side stores this verbatim.
+# ---------------------------------------------------------------------------
+def _embed_all_srcrevs(d):
+    src_uris = (d.getVar('SRC_URI') or '').split()
+
+    # Collect all name= values from SRC_URI fetch parameters
+    names = []
+    for uri in src_uris:
+        for param in uri.split(';')[1:]:
+            if param.startswith('name='):
+                name = param[5:]
+                if name and name not in names:
+                    names.append(name)
+
+    if names:
+        # Named SRCREVs - emit as "name=rev" pairs
+        pairs = []
+        for name in names:
+            rev = d.getVar('SRCREV_%s' % name) or 'INVALID'
+            pairs.append('%s=%s' % (name, rev))
+        return ' '.join(pairs)
+    else:
+        # Single unnamed SRCREV (or tarball-only recipe)
+        return d.getVar('SRCREV') or 'INVALID'
+
+# ---------------------------------------------------------------------------
+# Append two custom fields to every IPK control file.
+# PACKAGE_ADD_METADATA_IPK accepts newline-separated "Key: value" strings
+# (see package.bbclass -> get_package_additional_metadata).
+# Using :append so we do not overwrite any existing custom metadata.
+#
+# Fields added to each IPK CONTROL/control:
+#   Source-URI: <space-separated list of all non-patch source URLs>
+#   Source-Rev: <rev>  |  <name1=rev1 name2=rev2 ...>
+# ---------------------------------------------------------------------------
+PACKAGE_ADD_METADATA_IPK:append = "\nSource-URI: ${@_embed_all_src_uris(d)}\nSource-Rev: ${@_embed_all_srcrevs(d)}"
+

--- a/classes/embed-source-metadata.bbclass
+++ b/classes/embed-source-metadata.bbclass
@@ -128,15 +128,18 @@ def _embed_all_srcrevs(d):
                     names.append(name)
 
     if names:
-        # Named SRCREVs - emit as "name=rev" pairs
+        # Named SRCREVs - emit only names that actually resolve to a revision.
+        # This avoids serializing empty values such as "src=" for non-SCM
+        # SRC_URI entries that happen to use ;name= for labeling.
         pairs = []
         for name in names:
-            rev = d.getVar('SRCREV_%s' % name) or ''
-            pairs.append('%s=%s' % (name, rev))
-        return ' '.join(pairs)
-    else:
-        # Single unnamed SRCREV (or tarball-only recipe)
-        return d.getVar('SRCREV') or ''
+            rev = d.getVar('SRCREV_%s' % name)
+            if rev:
+                pairs.append('%s=%s' % (name, rev))
+        if pairs:
+            return ' '.join(pairs)
+    # Single unnamed SRCREV (or tarball-only recipe, or no valid named SRCREVs)
+    return d.getVar('SRCREV') or ''
 
 # ---------------------------------------------------------------------------
 # Append two custom fields to every IPK control file.

--- a/classes/embed-source-metadata.bbclass
+++ b/classes/embed-source-metadata.bbclass
@@ -19,9 +19,8 @@
 # Author: Arjun <arjun_daasuramdass@comcast.com>
 
 # ---------------------------------------------------------------------------
-# Helper: return ALL meaningful (non-patch) source URIs, space-separated,
-# normalised to web-browsable HTTPS URLs so AI tools can form direct
-# file permalinks without further transformation.
+# Helper: return all non-file:// source URIs, space-separated,
+# normalised to web-browsable HTTPS URLs.
 #
 # Normalisation rules applied per URI:
 #   1. Skip all file:// entries (patches, diffs, config files, service units

--- a/classes/manifest-srcuri.bbclass
+++ b/classes/manifest-srcuri.bbclass
@@ -201,17 +201,15 @@ python manifest_srcuri_enrich() {
         # mark as N/A -- the recipe .bb name is already in the Recipe column.
         src_uri = meta.get('Source-URI', '') or meta.get('Source', '')
 
-        # Strip any file:// tokens that may be present in older IPKs
-        # published before embed-source-metadata.bbclass was fixed to
-        # exclude all file:// entries (not just .patch/.diff).
-        # After filtering, keep all remaining remote URLs -- recipes with
-        # multiple repos (e.g. apparmor-generic has rdk-apparmor-profiles
-        # + apparmor-profiles) need both URLs to match their SRCREVs.
-        remote_uris = [t for t in src_uri.split() if not t.startswith('file://')]
+        # Strip any file:// tokens and the 'unknown' sentinel emitted by
+        # embed-source-metadata.bbclass when no remote URIs exist.
+        # After filtering, keep all remaining remote URLs.
+        remote_uris = [t for t in src_uri.split()
+                       if not t.startswith('file://') and t != 'unknown']
         src_uri = ' '.join(remote_uris) if remote_uris else 'N/A'
 
         src_rev = meta.get('Source-Rev', '')
-        if not src_rev:
+        if not src_rev or src_rev in ('INVALID', 'unknown'):
             # Fall back to hash extracted from the version string (git fetcher
             # encodes SRCREV as +git0+<hash>).  If no hash is found (tarball
             # recipes, suppressed SRCREV), use N/A rather than the Yocto-internal

--- a/classes/manifest-srcuri.bbclass
+++ b/classes/manifest-srcuri.bbclass
@@ -92,12 +92,12 @@ def _parse_feed_indexes(tmpdir, oe_rootfs_repo):
 # ---------------------------------------------------------------------------
 # Helper -- try to extract a short SRCREV hash from a BitBake version string.
 # Handles AUTOINC / git fetcher patterns, e.g.:
-#   1.0+git0+7c6608d0db-r1        -> 7c6608d0db
-#   20211102.0+git0+7c6608d0db-r1 -> 7c6608d0db
-#   1.10+git+0+0f1b43536d-r0      -> 0f1b43536d
-#   1.2.1gitr+0+18c4c982a5-r0     -> 18c4c982a5
+#   1.0+git0+7c6608d0db-r1         -> 7c6608d0db
+#   20211102.0+git0+7c6608d0db-r1  -> 7c6608d0db
+#   1.10+git+0+0f1b43536d-r0       -> 0f1b43536d
+#   1.2.1gitr+0+18c4c982a5-r0      -> 18c4c982a5
 #   1.2.3+gitAUTOINC+18c4c982a5-r0 -> 18c4c982a5
-#   25.lts+git0+hash1_hash2-r30   -> hash1_hash2 (multi-SRCREV)
+#   25.lts+git0+abc123_def456-r30  -> abc123_def456 (multi-SRCREV, hex only)
 # Returns None when no hash is found (plain version or bare git-r0).
 # ---------------------------------------------------------------------------
 def _srcrev_from_version(ver):
@@ -195,11 +195,17 @@ python manifest_srcuri_enrich() {
 
         recipe = meta.get('OE', 'unknown')
 
-        # Source-URI: prefer field from embed-source-metadata.bbclass,
-        # fall back to standard Source: field (.bb filename).
+        # Source-URI: prefer field from embed-source-metadata.bbclass.
+        # Only fall back to Source: when it looks like a real URL (contains
+        # ://) -- in opkg Packages stanzas the Source: field is typically a
+        # recipe/source identifier (.bb filename), not a URL.
         # If neither is available, or all tokens are file:// local paths,
         # mark as N/A -- the recipe .bb name is already in the Recipe column.
-        src_uri = meta.get('Source-URI', '') or meta.get('Source', '')
+        src_uri = meta.get('Source-URI', '')
+        if not src_uri:
+            source_fallback = meta.get('Source', '')
+            if '://' in source_fallback:
+                src_uri = source_fallback
 
         # Strip any file:// tokens and the 'unknown' sentinel emitted by
         # embed-source-metadata.bbclass when no remote URIs exist.

--- a/classes/manifest-srcuri.bbclass
+++ b/classes/manifest-srcuri.bbclass
@@ -26,7 +26,8 @@
 # Author: Arjun <arjun_daasuramdass@comcast.com>
 
 # ---------------------------------------------------------------------------
-# Helper -- parse all feed index files and return a dict keyed by package name.
+# Helper -- parse all feed index files and return a dict keyed by
+# (Package, Version, Architecture) 3-tuple.
 # Each value is a dict of the fields from that package's stanza.
 #
 # Two sources are scanned so both build modes are covered:
@@ -95,12 +96,16 @@ def _parse_feed_indexes(tmpdir, oe_rootfs_repo):
 #   20211102.0+git0+7c6608d0db-r1 -> 7c6608d0db
 #   1.10+git+0+0f1b43536d-r0      -> 0f1b43536d
 #   1.2.1gitr+0+18c4c982a5-r0     -> 18c4c982a5
+#   1.2.3+gitAUTOINC+18c4c982a5-r0 -> 18c4c982a5
 #   25.lts+git0+hash1_hash2-r30   -> hash1_hash2 (multi-SRCREV)
 # Returns None when no hash is found (plain version or bare git-r0).
 # ---------------------------------------------------------------------------
 def _srcrev_from_version(ver):
     import re
-    m = re.search(r'\+git[r]?[0-9]*\+([0-9a-f][0-9a-f_]+)', ver)
+    # Match git/gitr marker with optional AUTOINC, +N, or bare digit suffix,
+    # followed by + and the hex hash.  Negative lookbehind prevents matching
+    # 'git' inside longer words (e.g. 'digital').
+    m = re.search(r'(?<![a-zA-Z])git[rR]?(?:AUTOINC|\+[0-9]+|[0-9]*)?\+([0-9a-f][0-9a-f_]+)', ver)
     if m:
         return m.group(1)
     return None

--- a/classes/manifest-srcuri.bbclass
+++ b/classes/manifest-srcuri.bbclass
@@ -166,18 +166,17 @@ python manifest_srcuri_enrich() {
     # Source-Rev) can be arbitrarily long and are left unpadded.
     import re as _re
     def _version_lookup_candidates(ver):
-        seen = set()
-        candidates = []
-        for c in [
-            ver,
-            _re.sub(r'-r\d+$', '', ver),
-            ver.split(':', 1)[1] if ':' in ver else None,
-            _re.sub(r'-r\d+$', '', ver.split(':', 1)[1]) if ':' in ver else None,
-        ]:
-            if c and c not in seen:
-                seen.add(c)
-                candidates.append(c)
-        return candidates
+        # Build a deduplicated ordered list of version strings to try.
+        # Strip only the trailing -rN Yocto revision suffix (not "-rc1" etc.).
+        # Also try epoch-stripped variants (epoch is the "N:" prefix in ver).
+        ver_plain = _re.sub(r'-r\d+$', '', ver)
+        if ':' in ver:
+            no_epoch = ver.split(':', 1)[1]
+            no_epoch_plain = _re.sub(r'-r\d+$', '', no_epoch)
+            raw = [ver, ver_plain, no_epoch, no_epoch_plain]
+        else:
+            raw = [ver, ver_plain]
+        return list(dict.fromkeys(v for v in raw if v))
 
     rows = []
     for pkg in sorted(pkgs):

--- a/classes/manifest-srcuri.bbclass
+++ b/classes/manifest-srcuri.bbclass
@@ -166,21 +166,17 @@ python manifest_srcuri_enrich() {
     # Source-Rev) can be arbitrarily long and are left unpadded.
     import re as _re
     def _version_lookup_candidates(ver):
-        candidates = []
         seen = set()
-        def _add(c):
+        candidates = []
+        for c in [
+            ver,
+            _re.sub(r'-r\d+$', '', ver),
+            ver.split(':', 1)[1] if ':' in ver else None,
+            _re.sub(r'-r\d+$', '', ver.split(':', 1)[1]) if ':' in ver else None,
+        ]:
             if c and c not in seen:
                 seen.add(c)
                 candidates.append(c)
-        _add(ver)
-        # Strip only the trailing Yocto/IPK revision suffix (-r<N>), not
-        # upstream version content such as "-rc1" or other hyphenated parts.
-        _add(_re.sub(r'-r\d+$', '', ver))
-        # Also consider epoch-stripped variants if present.
-        if ':' in ver:
-            ver_no_epoch = ver.split(':', 1)[1]
-            _add(ver_no_epoch)
-            _add(_re.sub(r'-r\d+$', '', ver_no_epoch))
         return candidates
 
     rows = []

--- a/classes/manifest-srcuri.bbclass
+++ b/classes/manifest-srcuri.bbclass
@@ -1,0 +1,257 @@
+# manifest-srcuri.bbclass
+#
+# Enriches rootfs.manifest with Recipe, Source-URI, and Source-Rev for each
+# installed package.  Reads source metadata from two complementary sources:
+#
+#   - Assembler builds: ${TMPDIR}/ipk_pkgdata/feed_info/index/<feed-name>
+#     (Packages indexes downloaded from remote opkg feeds)
+#   - Local builds:     ${WORKDIR}/oe-rootfs-repo/<arch>/Packages
+#     (repo assembled by poky inside do_rootfs, indexed with -f)
+#
+# Both sources are merged; where a package appears in both, the local
+# oe-rootfs-repo entry wins so the most-recently-built metadata takes
+# precedence.
+#
+# Output columns in rootfs.manifest:
+#   Package  Arch  Version  Recipe  Source-URI  Source-Rev
+#
+# Source-URI / Source-Rev are populated only when the building layer
+# inherits embed-source-metadata.bbclass.  For git-based packages whose
+# version string embeds a short hash (e.g. 1.0+git0+7c6608d0db-r1) the
+# hash is extracted automatically as a partial fallback.
+#
+# Usage:
+#   INHERIT += "manifest-srcuri"  (in local.conf or image conf)
+#
+# Author: Arjun <arjun_daasuramdass@comcast.com>
+
+# ---------------------------------------------------------------------------
+# Helper -- parse all feed index files and return a dict keyed by package name.
+# Each value is a dict of the fields from that package's stanza.
+#
+# Two sources are scanned so both build modes are covered:
+#
+#   1. Assembler mode (remote IPK feeds):
+#        ${TMPDIR}/ipk_pkgdata/feed_info/index/<feed-name>
+#      These are the Packages indexes downloaded from remote opkg feeds
+#      (Artifactory).  Present in assembler builds; absent in local builds.
+#
+#   2. Local build mode (oe-rootfs-repo):
+#        ${WORKDIR}/oe-rootfs-repo/<arch>/Packages
+#      Poky assembles this temporary repo inside do_rootfs from the locally
+#      built IPKs before installing them.  It is always present when
+#      manifest_srcuri_enrich runs (DEPLOY_DIR_IPK/Packages may not exist
+#      yet because do_package_index can run after do_rootfs).
+#
+# Both sources are merged into one dict.  Where a package appears in both
+# (e.g. a remote sstate hit plus a local override), the oe-rootfs-repo entry
+# wins (scanned last) so the most-recently-built metadata takes precedence.
+# ---------------------------------------------------------------------------
+def _parse_feed_indexes(tmpdir, oe_rootfs_repo):
+    import os
+    import glob
+
+    pkg_meta = {}
+
+    def _parse_file(index_file):
+        current = {}
+        with open(index_file, 'r', errors='replace') as f:
+            for line in f:
+                line = line.rstrip('\n')
+                if line == '':
+                    if 'Package' in current and 'Version' in current and 'Architecture' in current:
+                        key = (current['Package'], current['Version'], current['Architecture'])
+                        pkg_meta[key] = current
+                    current = {}
+                elif ': ' in line:
+                    key, _, val = line.partition(': ')
+                    current[key.strip()] = val.strip()
+        if 'Package' in current and 'Version' in current and 'Architecture' in current:
+            key = (current['Package'], current['Version'], current['Architecture'])
+            pkg_meta[key] = current
+
+    # Source 1: remote feed indexes (assembler pattern)
+    index_dir = os.path.join(tmpdir, 'ipk_pkgdata', 'feed_info', 'index')
+    for index_file in glob.glob(os.path.join(index_dir, '*')):
+        if os.path.isfile(index_file):
+            _parse_file(index_file)
+
+    # Source 2: oe-rootfs-repo Packages indexes (local build pattern).
+    # Poky assembles this repo inside do_rootfs and indexes it with -f,
+    # so Source-URI / Source-Rev fields are preserved.  Always available
+    # when manifest_srcuri_enrich runs, unlike DEPLOY_DIR_IPK which may
+    # not be indexed yet (do_package_index can run after do_rootfs).
+    if oe_rootfs_repo and os.path.isdir(oe_rootfs_repo):
+        for packages_file in glob.glob(os.path.join(oe_rootfs_repo, '*', 'Packages')):
+            if os.path.isfile(packages_file):
+                _parse_file(packages_file)
+
+    return pkg_meta
+
+# ---------------------------------------------------------------------------
+# Helper -- try to extract a short SRCREV hash from a BitBake version string.
+# Handles AUTOINC / git fetcher patterns, e.g.:
+#   1.0+git0+7c6608d0db-r1        -> 7c6608d0db
+#   20211102.0+git0+7c6608d0db-r1 -> 7c6608d0db
+#   1.10+git+0+0f1b43536d-r0      -> 0f1b43536d
+#   1.2.1gitr+0+18c4c982a5-r0     -> 18c4c982a5
+#   25.lts+git0+hash1_hash2-r30   -> hash1_hash2 (multi-SRCREV)
+# Returns None when no hash is found (plain version or bare git-r0).
+# ---------------------------------------------------------------------------
+def _srcrev_from_version(ver):
+    import re
+    m = re.search(r'\+git[r]?[0-9]*\+([0-9a-f][0-9a-f_]+)', ver)
+    if m:
+        return m.group(1)
+    return None
+
+# ---------------------------------------------------------------------------
+# Enrich the rootfs manifest with source metadata.
+#
+# Hooked via ROOTFS_POSTUNINSTALL_COMMAND:append so it runs AFTER poky's
+# write_image_manifest (from rootfs-postcommands.bbclass).  Defining the
+# function as a plain "python write_image_manifest()" would be silently
+# overridden by poky's version because image recipe inherits
+# rootfs-postcommands.bbclass AFTER the global INHERIT is processed, so
+# poky's definition always wins the last-parsed-wins rule.
+#
+# By appending our own uniquely-named function to the post-uninstall
+# command list we avoid the naming conflict entirely.  Our function runs
+# after poky has written the basic 3-column manifest and overwrites it
+# with the enriched 6-column version.
+# ---------------------------------------------------------------------------
+
+ROOTFS_POSTUNINSTALL_COMMAND:append = " manifest_srcuri_enrich ; "
+
+python manifest_srcuri_enrich() {
+    import os
+    from oe.rootfs import image_list_installed_packages
+
+    deploy_dir    = d.getVar('IMGDEPLOYDIR')
+    link_name     = d.getVar('IMAGE_LINK_NAME')
+    manifest_name = d.getVar('IMAGE_MANIFEST')
+    tmpdir        = d.getVar('TMPDIR')
+    workdir       = d.getVar('WORKDIR')
+
+    if not manifest_name:
+        return
+
+    # oe-rootfs-repo is the temporary IPK repo that poky assembles inside
+    # do_rootfs from locally-built packages before installing them.  It is
+    # always present when manifest_srcuri_enrich runs.  DEPLOY_DIR_IPK, by
+    # contrast, may not have its Packages indexes yet -- do_package_index
+    # can execute after do_rootfs in the BitBake task graph, so its Packages
+    # files may not exist at this point.
+    #
+    # Poky now calls opkg-make-index with -f, so Source-URI / Source-Rev
+    # fields are already preserved in the oe-rootfs-repo Packages indexes.
+    # No re-indexing is needed here.
+    oe_rootfs_repo = os.path.join(workdir, 'oe-rootfs-repo') if workdir else ''
+
+    # Build package -> metadata lookup from all feed index files.
+    # Scans remote feed_info/index/ (assembler) and oe-rootfs-repo (local builds).
+    pkg_meta = _parse_feed_indexes(tmpdir, oe_rootfs_repo)
+    if not pkg_meta:
+        bb.warn("manifest-srcuri: no feed index files found under "
+                "%s/ipk_pkgdata/feed_info/index/ or %s -- "
+                "Source-URI / Source-Rev columns will be empty." % (tmpdir, oe_rootfs_repo))
+
+    # Get the installed package list (arch + version) -- same call used
+    # by poky's standard write_image_manifest.
+    pkgs = image_list_installed_packages(d)
+
+    # Build all rows first so we can compute column widths for pretty-printing.
+    # Columns 1-4 (Package, Arch, Version, Recipe) have bounded widths and are
+    # padded so the file is readable with plain `cat`.  Columns 5-6 (Source-URI,
+    # Source-Rev) can be arbitrarily long and are left unpadded.
+    import re as _re
+    def _version_lookup_candidates(ver):
+        candidates = []
+        seen = set()
+        def _add(c):
+            if c and c not in seen:
+                seen.add(c)
+                candidates.append(c)
+        _add(ver)
+        # Strip only the trailing Yocto/IPK revision suffix (-r<N>), not
+        # upstream version content such as "-rc1" or other hyphenated parts.
+        _add(_re.sub(r'-r\d+$', '', ver))
+        # Also consider epoch-stripped variants if present.
+        if ':' in ver:
+            ver_no_epoch = ver.split(':', 1)[1]
+            _add(ver_no_epoch)
+            _add(_re.sub(r'-r\d+$', '', ver_no_epoch))
+        return candidates
+
+    rows = []
+    for pkg in sorted(pkgs):
+        arch = pkgs[pkg].get('arch', 'unknown')
+        ver  = pkgs[pkg].get('ver',  'unknown')
+        meta = {}
+        for lookup_ver in _version_lookup_candidates(ver):
+            meta = pkg_meta.get((pkg, lookup_ver, arch)) or {}
+            if meta:
+                break
+
+        recipe = meta.get('OE', 'unknown')
+
+        # Source-URI: prefer field from embed-source-metadata.bbclass,
+        # fall back to standard Source: field (.bb filename).
+        # If neither is available, or all tokens are file:// local paths,
+        # mark as N/A -- the recipe .bb name is already in the Recipe column.
+        src_uri = meta.get('Source-URI', '') or meta.get('Source', '')
+
+        # Strip any file:// tokens that may be present in older IPKs
+        # published before embed-source-metadata.bbclass was fixed to
+        # exclude all file:// entries (not just .patch/.diff).
+        # After filtering, keep all remaining remote URLs -- recipes with
+        # multiple repos (e.g. apparmor-generic has rdk-apparmor-profiles
+        # + apparmor-profiles) need both URLs to match their SRCREVs.
+        remote_uris = [t for t in src_uri.split() if not t.startswith('file://')]
+        src_uri = ' '.join(remote_uris) if remote_uris else 'N/A'
+
+        src_rev = meta.get('Source-Rev', '')
+        if not src_rev:
+            # Fall back to hash extracted from the version string (git fetcher
+            # encodes SRCREV as +git0+<hash>).  If no hash is found (tarball
+            # recipes, suppressed SRCREV), use N/A rather than the Yocto-internal
+            # sentinel "INVALID" which has no meaning to manifest consumers.
+            src_rev = _srcrev_from_version(ver) or 'N/A'
+
+        rows.append((pkg, arch, ver, recipe, src_uri, src_rev))
+
+    # Column widths for the four bounded columns (pad to at least the header width).
+    col_w = [
+        max(len('Package'),  max(len(r[0]) for r in rows) if rows else 0),
+        max(len('Arch'),     max(len(r[1]) for r in rows) if rows else 0),
+        max(len('Version'),  max(len(r[2]) for r in rows) if rows else 0),
+        max(len('Recipe'),   max(len(r[3]) for r in rows) if rows else 0),
+    ]
+
+    def _fmt(row, comment=False):
+        line = '  '.join([
+            row[0].ljust(col_w[0]),
+            row[1].ljust(col_w[1]),
+            row[2].ljust(col_w[2]),
+            row[3].ljust(col_w[3]),
+            row[4],
+            row[5],
+        ])
+        if comment:
+            line = '# ' + line
+        return line + '\n'
+
+    with open(manifest_name, 'w+') as mf:
+        # Header line is commented so plain package-list parsers can skip it.
+        mf.write(_fmt(('Package', 'Arch', 'Version', 'Recipe', 'Source-URI', 'Source-Rev'), comment=True))
+        for row in rows:
+            mf.write(_fmt(row))
+
+    # Maintain the IMAGE_LINK_NAME.manifest symlink (same as poky)
+    if os.path.exists(manifest_name) and link_name:
+        manifest_link = deploy_dir + "/" + link_name + ".manifest"
+        if manifest_link != manifest_name:
+            if os.path.lexists(manifest_link):
+                os.remove(manifest_link)
+            os.symlink(os.path.basename(manifest_name), manifest_link)
+}


### PR DESCRIPTION
Reason for change:
manifest-srcuri: enrich rootfs.manifest with Recipe, Source-URI, Source-Rev

Add manifest-srcuri.bbclass to produce an enriched 6-column rootfs.manifest (Package, Arch, Version, Recipe, Source-URI, Source-Rev) for image recipes that inherit it.

Source metadata is read from two complementary sources:
- Assembler builds: ipk_pkgdata/feed_info/index/ (remote opkg feed indexes)
- Local builds: oe-rootfs-repo/<arch>/Packages (assembled by poky during do_rootfs, indexed with -f so user-defined fields are preserved)

embed-source-metadata: embed Source-URI and Source-Rev into IPK control files

Add embed-source-metadata.bbclass to bake source provenance fields into the CONTROL/control member of every IPK produced by a recipe.  These fields flow through the build pipeline into the feed's Packages index, making them available to assembler builds that consume pre-built IPKs without access to the original recipe files or PKGDATA_DIR.