### PR TITLE
RDKEMW-10733: mauth-certs.service failure

### DIFF
--- a/classes/package_categories.bbclass
+++ b/classes/package_categories.bbclass
@@ -32,6 +32,6 @@ PACKAGE_CATEGORY[qt] = "^qt.*"
 PACKAGE_CATEGORY[qualcom] = "^qca6390.*"
 PACKAGE_CATEGORY[voice] = "^ctrlm.* ^xraudio.* ^xr-speech.* ^xr-voice.* ^xr-dsp.* ^xr-mq.* ^xr-sm.* ^xr-time.* ^sky-mic-test.*"
 PACKAGE_CATEGORY[thunder] = "^wpeframework.* ^rdkservices.* ^thunder.*"
-PACKAGE_CATEGORY[security] = "^lxy ^acscerts ^authservice.* ^ca-certificates ^caupdate ^dropbear ^ecfs-search ^ecryptfs-utils ^libcrypto ^libgcrypt ^libgpg.* ^liboauth ^libpam.* ^libseccomp ^libssl ^libwrap ^libxcrypt ^mauth-certs ^nettle ^openssl.* ^pam.* ^rdk-ca-store ^rdkxpkiutl ^samhain ^secapi.* ^secauthn ^secclient ^secure-tee ^shadow.* ^sslcerts ^tee-supplicant ^trower-base64 ^optee.* ^xsign ^socprov.* ^apparmor ^mtsdownloader ^ssacpc"
+PACKAGE_CATEGORY[security] = "^lxy ^acscerts ^authservice.* ^ca-certificates ^caupdate ^dropbear ^ecfs-search ^ecryptfs-utils ^libcrypto ^libgcrypt ^libgpg.* ^liboauth ^libpam.* ^libseccomp ^libssl ^libwrap ^libxcrypt ^nettle ^openssl.* ^pam.* ^rdk-ca-store ^rdkxpkiutl ^samhain ^secapi.* ^secauthn ^secclient ^secure-tee ^shadow.* ^sslcerts ^tee-supplicant ^trower-base64 ^optee.* ^xsign ^socprov.* ^apparmor ^mtsdownloader ^ssacpc"
 PACKAGE_CATEGORY[webserver] = "^civetweb ^libnghttp2 ^libsoup.* ^lighttpd.* ^mongoose ^nghttp2.* ^fcgi ^spawn-fcgi"
 


### PR DESCRIPTION
Reason for change: webapps in EntOS utilize client certificates from the app widget and do not rely on the device certificates prepared by the mauth-certs service.
Test Procedure: check whether mauth.certificate service is running
Priority: P1
Risks: None