### PR TITLE
RDKEMW-18539: Override AppArmor generic defaults with vendor defaults

### DIFF
--- a/classes/apparmor_binprofiles.bbclass
+++ b/classes/apparmor_binprofiles.bbclass
@@ -8,8 +8,22 @@ SUMMARY = "AppArmor profile compilation"
 #
 DEPENDS:append = " apparmor-native "
 
-ROOTFS_POSTPROCESS_COMMAND:append = " execute_aa_compile_std_profiles;"
+ROOTFS_POSTPROCESS_COMMAND:append = " override_apparmor_generic_defaults; execute_aa_compile_std_profiles;"
 
+override_apparmor_generic_defaults() {
+   if [ -z "${IMAGE_ROOTFS}" ] || [ ! -d "${IMAGE_ROOTFS}" ]; then
+        bbfatal "override_apparmor_generic_defaults requires IMAGE_ROOTFS to be set to a valid rootfs directory"
+    fi
+    GENERIC_AA_DEFAULTS="${R}/etc/apparmor/apparmor_generic_defaults"
+    VENDOR_AA_DEFAULTS="${R}/etc/apparmor.d/vendor/apparmor_defaults"
+
+    if [ -f "${VENDOR_AA_DEFAULTS}" ]; then
+        bbnote "Overriding apparmor_generic_defaults with apparmor_vendor_defaults"
+
+        install -d "$(dirname "${GENERIC_AA_DEFAULTS}")"
+        cp -f "${VENDOR_AA_DEFAULTS}" "${GENERIC_AA_DEFAULTS}"
+    fi
+}
 execute_aa_compile_std_profiles() {
     install -d ${R}/etc/apparmor.d/
     install -d ${R}/etc/apparmor/binprofiles/


### PR DESCRIPTION
Reason for change: Apparmor profile can be controlled from Vendor during the bring-up stage on RDKE
Test Procedure: As mentioned in the ticket
Risks: Medium