### PR TITLE
RDKBACCL-1828: Make 6.12 kernel build changes in wrynose build

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,7 +12,7 @@ BBFILE_PATTERN_meta-rdk-auxiliary = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rdk-auxiliary = "6"
 
 LAYERDEPENDS_meta-rdk-auxiliary = "core"
-LAYERSERIES_COMPAT_meta-rdk-auxiliary = "dunfell kirkstone"
+LAYERSERIES_COMPAT_meta-rdk-auxiliary = "dunfell kirkstone wrynose"
 
 require include/image-classes.inc
 require include/user-classes.inc


### PR DESCRIPTION
Reason for change : Added wrynose compat support to this layer
Test procedure: None
Risk: None