### PR TITLE
RDKOSS-961: Changes to support Hash Equivalence

### DIFF
--- a/classes/logrotate_config.bbclass
+++ b/classes/logrotate_config.bbclass
@@ -1,12 +1,13 @@
 SUMMARY = "Generate a information to build logrotate data configuration for the recipe"
 
-python do_write_metadata_logrotate() {
+fakeroot python do_write_metadata_logrotate() {
 
     import os
     log_path = "/opt/logs"
     metadata_dir = d.expand('${D}${sysconfdir}')  + "/logrotate/"
     if not os.path.exists(metadata_dir):
-        os.makedirs(metadata_dir)
+        bb.utils.mkdirhier(metadata_dir)
+        os.chown(metadata_dir, 0, 0)
     if d.getVar('LOGROTATE_NAME', True) != None:
         name_list = d.getVar('LOGROTATE_NAME', True).split()
         for fname in name_list:

--- a/classes/syslog-ng-config-gen.bbclass
+++ b/classes/syslog-ng-config-gen.bbclass
@@ -11,7 +11,8 @@ fakeroot python do_write_metadata_syslog_ng() {
         bb.utils.mkdirhier(metadata_dir)
         os.chown(metadata_dir, 0, 0)
     if not os.path.exists(filter_dir):
-        os.makedirs(filter_dir)
+        bb.utils.mkdirhier(filter_dir)
+        os.chown(filter_dir, 0, 0)        
     if d.getVar('SYSLOG-NG_FILTER', True) != None:
         with open(filter_file, 'w') as filterfile:
             with open(config_file, 'w') as conf:

--- a/classes/syslog-ng-config-gen.bbclass
+++ b/classes/syslog-ng-config-gen.bbclass
@@ -1,6 +1,6 @@
 SUMMARY = "Generate a meta information of syslog-ng configuration details for the recipe"
 
-python do_write_metadata_syslog_ng() {
+fakeroot python do_write_metadata_syslog_ng() {
 
     import os
     metadata_dir = d.expand('${D}${sysconfdir}')  + "/syslog-ng/metadata/"
@@ -8,7 +8,8 @@ python do_write_metadata_syslog_ng() {
     config_file = metadata_dir + d.getVar('PN', True) + ".metadata"
     filter_file = filter_dir + d.getVar('PN', True) + ".filter"
     if not os.path.exists(metadata_dir):
-        os.makedirs(metadata_dir)
+        bb.utils.mkdirhier(metadata_dir)
+        os.chown(metadata_dir, 0, 0)
     if not os.path.exists(filter_dir):
         os.makedirs(filter_dir)
     if d.getVar('SYSLOG-NG_FILTER', True) != None:

--- a/classes/syslog-ng-config-gen.bbclass
+++ b/classes/syslog-ng-config-gen.bbclass
@@ -12,7 +12,7 @@ fakeroot python do_write_metadata_syslog_ng() {
         os.chown(metadata_dir, 0, 0)
     if not os.path.exists(filter_dir):
         bb.utils.mkdirhier(filter_dir)
-        os.chown(filter_dir, 0, 0)        
+        os.chown(filter_dir, 0, 0)
     if d.getVar('SYSLOG-NG_FILTER', True) != None:
         with open(filter_file, 'w') as filterfile:
             with open(config_file, 'w') as conf:


### PR DESCRIPTION
Reason for change : To avoid file permission change thus avoiding sstate sig validation error
Test procuedure : Build and verify with Hash equivalence enabled
Risk: Low