### PR TITLE
RDKBACCL-1837 : Build core-image-minimal for wrynose

### DIFF
--- a/classes/post-rootfs-hooks.bbclass
+++ b/classes/post-rootfs-hooks.bbclass
@@ -93,11 +93,17 @@ disable_agetty() {
 
 # Required for NetworkManager
 create_NM_link() {
-    touch ${R}/etc/resolv.conf
-    echo "nameserver 127.0.0.1" > ${R}/etc/resolv.conf
-    echo "options timeout:1" >> ${R}/etc/resolv.conf
-    echo "options attempts:2" >> ${R}/etc/resolv.conf
-    ln -sf /var/run/NetworkManager/no-stub-resolv.conf ${R}/etc/resolv.dnsmasq
+    install -d ${R}/etc
+    rm -f ${R}/etc/resolv.conf
+
+    cat > ${R}/etc/resolv.conf << EOF
+nameserver 127.0.0.1
+options timeout:1
+options attempts:2
+EOF
+
+    ln -snf /var/run/NetworkManager/no-stub-resolv.conf \
+        ${R}/etc/resolv.dnsmasq
 }
 
 remove_hvec_asset(){

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,7 +12,7 @@ BBFILE_PATTERN_meta-rdk-auxiliary = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rdk-auxiliary = "6"
 
 LAYERDEPENDS_meta-rdk-auxiliary = "core"
-LAYERSERIES_COMPAT_meta-rdk-auxiliary = "dunfell kirkstone"
+LAYERSERIES_COMPAT_meta-rdk-auxiliary = "dunfell kirkstone wrynose"
 
 require include/image-classes.inc
 require include/user-classes.inc


### PR DESCRIPTION
RDKBACCL-1837: Build core-image-minimal for wrynose 
Reason for change: Initial changes for wrynose build in BPI
Test Procedure: Check Wrynose build
Risks: Low
Priority: P1

Signed-off-by: ssaman560 <sipra_samantaray2@comcast.com>