### PR TITLE
RDKOSS-954:extract-sha256 bbclass

### DIFF
--- a/classes/extract-sha256-cve.bbclass
+++ b/classes/extract-sha256-cve.bbclass
@@ -1,0 +1,125 @@
+#extract-sha256-cve.bbclass
+#
+# Extracts SHA256 checksums for CVE layer feed entries at parse time.
+#
+# For each entry in CVE_LAYER_FEED_PATH this class:
+#   1. Extracts the artifact URL (the portion after ## and before ;)
+#   2. Fetches the SHA256 from the X-Checksum-Sha256 HTTP response header
+#      (mirrors the curl --netrc -sI -L behaviour of generate_sha256.sh)
+#   3. Sets the corresponding BitBake variable in the current datastore
+#   4. Appends  VAR = "SHA"  to ${TOPDIR}/conf/dynamic_sha.inc so the
+#      value is available to subsequent bitbake invocations as well
+#
+# Expected CVE_LAYER_FEED_PATH entry format:
+#   <name>##<url>;<param>;sha256sum=${VAR_NAME}[;<more-params>]
+#
+# Usage:
+#   inherit extract-sha256-cve   (in an image recipe or distro conf)
+# or
+#   INHERIT += "extract-sha256-cve"  (in local.conf)
+#
+# The class is guarded by a per-build sentinel so the network fetch
+# runs only once even when multiple recipes share the same cooker
+# process.
+
+python () {
+    import os
+    import re
+    import urllib.request
+    import urllib.parse
+
+    # skip cve-check is not enabled 
+    inherit_classes = (d.getVar("INHERIT") or"").split()
+    if "cve-check" not in inherit_classes:
+        bb.debug(1,"extract-sha256-cve:cve-check not enabled ,skipping")
+        return
+
+    topdir = d.getVar('TOPDIR')
+    sentinel = os.path.join(topdir, 'conf', '.extract_sha256_cve_done')
+
+    # Run only once per cooker session
+    if os.path.exists(sentinel):
+        bb.debug(1, "extract-sha256-cve: sentinel present, skipping regeneration")
+        return
+
+    cve_layer_feed_path = d.getVar('CVE_LAYER_FEED_PATH') or ''
+    if not cve_layer_feed_path.strip():
+        bb.debug(1, "extract-sha256-cve: CVE_LAYER_FEED_PATH is not set, nothing to do")
+        return
+
+    inc_file = os.path.join(topdir, 'conf', 'dynamic_sha.inc')
+
+    bb.note("extract-sha256-cve: generating CVE feed SHA256 checksums -> %s" % inc_file)
+
+    # Remove any stale inc file before writing fresh values
+    if os.path.exists(inc_file):
+        os.remove(inc_file)
+
+    for entry in cve_layer_feed_path.split():
+        entry = entry.strip()
+        if not entry:
+            continue
+
+        # Extract URL: the segment after ## up to the first ;
+        # e.g.  feedname##https://example.com/feed.xml;sha256sum=${FEED_SHA}
+        url_match = re.search(r'##([^;]+)', entry)
+        if not url_match:
+            bb.warn("extract-sha256-cve: cannot parse URL from entry: %s" % entry)
+            continue
+        url = url_match.group(1).strip()
+
+        # Extract the BitBake variable name from  sha256sum=${VAR_NAME}
+        var_match = re.search(r'sha256sum=\$\{([^}]+)\}', entry)
+        if not var_match:
+            bb.warn("extract-sha256-cve: cannot parse sha256sum variable from entry: %s" % entry)
+            continue
+        var_name = var_match.group(1).strip()
+
+        # Perform a HEAD request and read the X-Checksum-Sha256 header.
+        # Honour ~/.netrc credentials when present (mirrors curl --netrc).
+        sha = None
+        try:
+            req = urllib.request.Request(url, method='HEAD')
+
+            netrc_path = os.path.expanduser('~/.netrc')
+            if os.path.exists(netrc_path):
+                try:
+                    import netrc as netrc_module
+                    import base64
+                    parsed = urllib.parse.urlparse(url)
+                    creds = netrc_module.netrc(netrc_path).authenticators(parsed.hostname)
+                    if creds:
+                        token = base64.b64encode(
+                            ('%s:%s' % (creds[0], creds[2])).encode()
+                        ).decode()
+                        req.add_header('Authorization', 'Basic %s' % token)
+                except Exception:
+                    pass  # netrc parse failure is non-fatal
+
+
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                sha = (resp.headers.get('X-Checksum-Sha256') or '').strip()
+
+        except Exception as exc:
+            bb.warn("extract-sha256-cve: failed to fetch SHA for %s (%s) - skipping entry: %s"
+                    % (var_name, url, exc))
+            continue
+
+        if not sha:
+            bb.warn("extract-sha256-cve: empty X-Checksum-Sha256 header for %s (%s) - skipping entry"
+                    % (var_name, url))
+            continue
+
+        # Write  VAR = "SHA"  to the dynamic include file
+        with open(inc_file, 'a') as f:
+            f.write('%s = "%s"\n' % (var_name, sha))
+
+        # Also set the value in the current datastore for immediate use
+        d.setVar(var_name, sha)
+
+        bb.debug(1, "extract-sha256-cve: %s = %s" % (var_name, sha))
+
+    # Write sentinel so subsequent recipe parses skip this block
+    with open(sentinel, 'w') as f:
+        f.write('')
+}


### PR DESCRIPTION
This PR supports extraction of SHA256 checksum values for downloading/consolidating layered CVE artifacts

Changes:
Adds a new extract-sha256-cve.bbclass with functions to fetch layer sha256 checksums required for downloading CVE artifacts to generate CVE reports and consolidated manifests by populating a dynamic-sha.inc file.
Adds conditional inherit of this class depending on "Enable CVE check" for CVE packages accordingly.